### PR TITLE
Extracting relative path instead of string manipulation

### DIFF
--- a/gitignore.go
+++ b/gitignore.go
@@ -248,8 +248,10 @@ func (i *ignore) Absolute(path string, isdir bool) Match {
 	}
 
 	// extract the relative path of this file
-	_prefix := len(i._base) + 1
-	_rel := string(path[_prefix:])
+	_rel, err := filepath.Rel(i.Base(), path)
+	if err != nil {
+		return nil
+	}
 	return i.Relative(_rel, isdir)
 } // Absolute()
 


### PR DESCRIPTION
As mentioned in this [issue](https://github.com/denormal/go-gitignore/issues/3), panic scenario could occur in gitignore.go Absolute() method when len(inputPath) >= len(basePath), so it's better to use filepath.Rel() native method from "path/filePath" package